### PR TITLE
Fix $SYNO_PLATFORM case "X64"

### DIFF
--- a/SynoBuildConf/build
+++ b/SynoBuildConf/build
@@ -52,7 +52,7 @@ case $SYNO_PLATFORM in
         echo "Building for geminilake platform";
         QMAKE_FLAGS="-xplatform linux-g++-64"
         ;;
-    x64)
+    X64)
         echo "Building for x64 platform"
         QMAKE_FLAGS="-xplatform linux-g++-64"
         ;;


### PR DESCRIPTION
The "x" in the "x64"-case needs to be a capital letter, otherwise the case is not recognized and the build exits with "Unsupported platform: X64".